### PR TITLE
A very basic heterogeneous data support for saddle-hdf5

### DIFF
--- a/saddle-hdf5/src/test/scala/org/saddle/io/H5StoreSpec.scala
+++ b/saddle-hdf5/src/test/scala/org/saddle/io/H5StoreSpec.scala
@@ -173,7 +173,7 @@ class H5StoreSpec extends Specification {
       H5Store.readFrame[Int, Int, Double](tmp, "df3")      must_== df3
       H5Store.readFrame[Long, Int, Double](tmp, "df4")     must_== df4
       H5Store.readFrame[Double, Int, Double](tmp, "df5")   must_== df5
-      //H5Store.readFrame[Int, Int, Any](tmp, "df6")         must_== df6
+      H5Store.readFrame[Int, Int, Any](tmp, "df6")         must_== df6
 
       Files.deleteIfExists(Paths.get(tmp))
 
@@ -197,7 +197,7 @@ class H5StoreSpec extends Specification {
       H5Store.readFrame[Int, Int, Double](fid, "df3")      must_== df3
       H5Store.readFrame[Long, Int, Double](fid, "df4")     must_== df4
       H5Store.readFrame[Double, Int, Double](fid, "df5")   must_== df5
-      //H5Store.readFrame[Int, Int, Any](tmp, "df6")         must_== df6
+      H5Store.readFrame[Int, Int, Any](tmp, "df6")         must_== df6
 
       // try slicing
       H5Store.readFrameSlice[DateTime, Int, Double](fid, "df1", d2, d3, 2, 3, true, true) must_== df1.colSliceBy(2, 3).rowSliceBy(d2, d3)


### PR DESCRIPTION
I've added a very basic support for writing/reading of `Frame`s with heteroneous column types. After studying some `.h5` files, I came to a conclusion (possibly incorrect) that pandas write doubles to block0 space, integers -- to block1 space, and strings -- to block2 space.

``` scala
[saddle-hdf5]$ console
[warn] Credentials file /home/folone/.ivy2/.credentials does not exist
[warn] Credentials file /home/folone/.ivy2/.credentials does not exist
[info] Compiling 1 Scala source to /home/folone/workspace/saddle/saddle-hdf5/target/scala-2.9.2/classes...
[info] Starting scala interpreter...
[info] 
import org.joda.time.DateTime
import org.saddle._
import org.saddle.time._
import org.saddle.io._
Welcome to Scala version 2.9.2 (OpenJDK 64-Bit Server VM, Java 1.7.0_21).
Type in expressions to have them evaluated.
Type :help for more information.

scala> val fid1 = H5Store.createFile("/home/folone/workspace/ad-ngrams/test.h5")
fid1: Int = 16777216

scala> val strVec = Vec("string", "another string", "unrelated")
strVec: org.saddle.Vec[java.lang.String] = 
[3 x 1]
        string
another string
     unrelated


scala> val intVec = vec.randi(3)
intVec: org.saddle.Vec[Int] = 
[3 x 1]
 -513254264
-1957777871
  644849453


scala> val df = Panel(strVec, intVec)
df: org.saddle.Frame[Int,Int,Any] = 
[3 x 2]
                  0           1 
     -------------- ----------- 
0 ->         string  -513254264 
1 -> another string -1957777871 
2 ->      unrelated   644849453 



scala> H5Store.writeFrame(fid1, "test", df)

scala> H5Store.readFrame[Int, Int, Any](fid1, "test")
res1: org.saddle.Frame[Int,Int,Any] = 
[3 x 2]
                  0           1 
     -------------- ----------- 
0 ->         string  -513254264 
1 -> another string -1957777871 
2 ->      unrelated   644849453 


scala> res1 == df
res2: Boolean = true

scala> H5Store.closeFile(fid1)

scala> :q
```
