### PR TITLE
Frame#isEmpty wasn't working correctly for case of sequence of empty vectors

### DIFF
--- a/saddle-core/src/main/scala/org/saddle/Frame.scala
+++ b/saddle-core/src/main/scala/org/saddle/Frame.scala
@@ -144,7 +144,7 @@ class Frame[RX: ST: ORD, CX: ST: ORD, T: ST](
   /**
    * Returns true if there are no values in the Frame
    */
-  def isEmpty: Boolean = (values.length == 0)
+  def isEmpty: Boolean = (values.numRows == 0)
 
   /**
    * The transpose of the frame (swapping the axes)


### PR DESCRIPTION
I noticed this when trying to do

``` scala
Frame("a"->Vec(1,2,3), "b"->Vec(4,5,6)).row(3).isEmpty
```
