### PR TITLE
Fix RRule.from iterator to return it with the time zone properly set.

### DIFF
--- a/saddle-core/src/main/scala/org/saddle/time/RRule.scala
+++ b/saddle-core/src/main/scala/org/saddle/time/RRule.scala
@@ -263,6 +263,7 @@ case class RRule private (freq: Frequency = DAILY,
    * provided DateTime instance.
    */
   def from(dt: DateTime): Iterator[DateTime] = {
+    val inzone = dt.getZone
     val riter = RecurrenceIteratorFactory.createRecurrenceIterator(toICal, dt2dtv(dt), inzone.toTimeZone)
 
     val iterWithJoins = joins.foldLeft(riter) { case (i1, (rrule, t)) =>

--- a/saddle-core/src/test/scala/org/saddle/time/RRuleCheck.scala
+++ b/saddle-core/src/test/scala/org/saddle/time/RRuleCheck.scala
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2013 Saddle Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package org.saddle.time
+
+import org.specs2.mutable.Specification
+import org.specs2.ScalaCheck
+import org.joda.time.{DateTime, DateTimeZone}
+
+class RRuleCheck extends Specification with ScalaCheck {
+
+  "RRule Tests" in {
+   
+    "RRule(DAILY).from(dt) must return an iterator that starts with dt" in {
+      val zoneNY = DateTimeZone.forID("America/New_York")
+      val zoneSP = DateTimeZone.forID("America/Sao_Paulo")
+      
+      // Ensures that the time zone of the testing datetime is different than the default one
+      val zone = if (DateTimeZone.getDefault == zoneNY) zoneSP else zoneNY
+      
+      val dt = new DateTime(2002, 11, 8, 0, 0, 0, 0, zone)
+      
+      val it = RRule(DAILY) from dt
+      
+      it.next must_== dt
+    }
+  }
+}


### PR DESCRIPTION
Look at the the code below:

``` scala
val dt = aDateTime.withZone(nonLocalTimeZone)
val it = RRule(DAILY) from dt
```

The original RRule.from method returned an iterator with the local time zone set. I think people would expect that it preserves the time zone from the DateTime instance provided.

I think that would fix the failing build in Travis introduced by the earlier pull request.
