### PR TITLE
Fix exception raised due to time zone offset transition for Brazilian time zone

### DIFF
--- a/saddle-core/src/test/scala/org/saddle/IndexArbitraries.scala
+++ b/saddle-core/src/test/scala/org/saddle/IndexArbitraries.scala
@@ -34,11 +34,13 @@ object IndexArbitraries {
     lst <- Gen.listOfN(l, Gen.chooseNum(0, l))
   } yield lst.toSet[Int].toSeq.toIndex
 
+  val zone = DateTimeZone.forID("America/New_York")
+  
   def getDate: Gen[DateTime] = for {
     m <- Gen.choose(1,12)
     d <- Gen.choose(1,28)
     y <- Gen.choose(2012, 2013)
-  } yield new DateTime(y, m, d, 0, 0, 0, 0)
+  } yield new DateTime(y, m, d, 0, 0, 0, 0, zone)
 
   def indexTimeWithDups: Gen[Index[DateTime]] = for {
     l <- Gen.choose(0, 100)


### PR DESCRIPTION
In Brazil, DST clock shifts occur at midnight, so some instants generated by IndexArbitraries were invalid.
Pass America/New_York time zone to DateTime constructor.
