### PR TITLE
Saddle data types should be serializable 

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -144,7 +144,7 @@ object Shared {
       </developers>
     ),
     scalaVersion := "2.10.3",
-    version := "1.3.3-SNAPSHOT",
+    version := "1.3.4-SNAPSHOT",
     crossScalaVersions := Seq("2.9.2", "2.9.3", "2.10.3", "2.11.0-RC1"),
     scalacOptions := Seq("-deprecation", "-unchecked"), // , "-Xexperimental"),
     shellPrompt := { (state: State) => "[%s]$ " format(Project.extract(state).currentProject.id) },

--- a/saddle-core/src/main/scala/org/saddle/Frame.scala
+++ b/saddle-core/src/main/scala/org/saddle/Frame.scala
@@ -124,7 +124,7 @@ import org.saddle.mat.MatCols
  */
 class Frame[RX: ST: ORD, CX: ST: ORD, T: ST](
   private[saddle] val values: MatCols[T], val rowIx: Index[RX], val colIx: Index[CX])
-  extends NumericOps[Frame[RX, CX, T]] {
+  extends NumericOps[Frame[RX, CX, T]] with Serializable{
 
   require(values.numRows == rowIx.length, "Row index length is incorrect")
   require(values.numCols == colIx.length, "Col index length is incorrect")

--- a/saddle-core/src/main/scala/org/saddle/Index.scala
+++ b/saddle-core/src/main/scala/org/saddle/Index.scala
@@ -30,7 +30,7 @@ import org.saddle.time.RRule
  * Index provides a constant-time look-up of a value within array-backed storage,
  * as well as operations to support joining and slicing.
  */
-trait Index[@spec(Boolean, Int, Long, Double) T] {
+trait Index[@spec(Boolean, Int, Long, Double) T] extends Serializable{
   protected def locator: Locator[T]
 
   /**

--- a/saddle-core/src/main/scala/org/saddle/Mat.scala
+++ b/saddle-core/src/main/scala/org/saddle/Mat.scala
@@ -61,7 +61,7 @@ import org.saddle.index.{IndexIntRange, Slice}
  *
  * @tparam A Type of elements within the Mat
  */
-trait Mat[@spec(Boolean, Int, Long, Double) A] extends NumericOps[Mat[A]] {
+trait Mat[@spec(Boolean, Int, Long, Double) A] extends NumericOps[Mat[A]] with Serializable{
   def scalarTag: ScalarTag[A]
 
   /**

--- a/saddle-core/src/main/scala/org/saddle/Series.scala
+++ b/saddle-core/src/main/scala/org/saddle/Series.scala
@@ -100,7 +100,7 @@ import org.saddle.mat.MatCols
  * @tparam T Type of elements in the values array, for which there must be an implicit ST
  */
 class Series[X: ST: ORD, T: ST](
-  val values: Vec[T], val index: Index[X]) extends NumericOps[Series[X, T]] {
+  val values: Vec[T], val index: Index[X]) extends NumericOps[Series[X, T]] with Serializable{
 
   require(values.length == index.length,
          "Values length %d != index length %d" format (values.length, index.length))

--- a/saddle-core/src/main/scala/org/saddle/Vec.scala
+++ b/saddle-core/src/main/scala/org/saddle/Vec.scala
@@ -69,7 +69,7 @@ import java.io.OutputStream
  *
  * @tparam T Type of elements within the Vec
  */
-trait Vec[@spec(Boolean, Int, Long, Double) T] extends NumericOps[Vec[T]] {
+trait Vec[@spec(Boolean, Int, Long, Double) T] extends NumericOps[Vec[T]] with Serializable{
   /**
    * The number of elements in the container                                                  F
    */

--- a/saddle-core/src/main/scala/org/saddle/index/IndexIntRange.scala
+++ b/saddle-core/src/main/scala/org/saddle/index/IndexIntRange.scala
@@ -32,10 +32,10 @@ import locator.Locator
 class IndexIntRange(val length: Int, val from: Int = 0) extends Index[Int] {
   require( length >= 0, "Length must be non-negative!" )
 
-  val scalarTag = ScalarTagInt
+  @transient lazy val scalarTag = ScalarTagInt
 
-  private lazy val asArr  = array.range(from, from + length)
-  private lazy val genIdx = Index(asArr)
+  @transient private lazy val asArr  = array.range(from, from + length)
+  @transient private lazy val genIdx = Index(asArr)
 
   /**
    * Custom implementation of a Locator to serve as the backing map in a

--- a/saddle-core/src/main/scala/org/saddle/index/IndexTime.scala
+++ b/saddle-core/src/main/scala/org/saddle/index/IndexTime.scala
@@ -38,17 +38,17 @@ import org.saddle.util.Concat.Promoter
 class IndexTime(val times: Index[Long],
                 val tzone: DateTimeZone = ISO_CHRONO.getZone) extends Index[DateTime] {
 
-  val scalarTag = ScalarTagTime
+  @transient lazy val scalarTag = ScalarTagTime
 
-  val chrono = ISO_CHRONO.withZone(tzone)
+  @transient lazy val chrono = ISO_CHRONO.withZone(tzone)
 
-  private val lmf = ScalarTagLong
+  @transient lazy private val lmf = ScalarTagLong
 
   private def l2t(l: Long) = if (lmf.isMissing(l)) scalarTag.missing else new DateTime(l, chrono)
   private def t2l(t: DateTime) = if (scalarTag.isMissing(t)) lmf.missing else t.getMillis
   private def il2it(l: Index[Long]) = new IndexTime(l, tzone)
 
-  private val _locator = new Locator[DateTime] {
+  @transient lazy private val _locator = new Locator[DateTime] {
     lazy val _keys = times.uniques.map(l2t)
 
     def contains(key: DateTime) = times.contains(t2l(key))
@@ -160,8 +160,8 @@ class IndexTime(val times: Index[Long],
 }
 
 object IndexTime {
-  private val st = ScalarTagTime
-  private val sl = ScalarTagLong
+  @transient lazy private val st = ScalarTagTime
+  @transient lazy private val sl = ScalarTagLong
 
   /**
    * Create a new IndexTime from a sequence of times

--- a/saddle-core/src/main/scala/org/saddle/locator/Locator.scala
+++ b/saddle-core/src/main/scala/org/saddle/locator/Locator.scala
@@ -41,7 +41,7 @@ import scala.{ specialized => spec }
  * }}}
  * where s(t) = min(i) for any i such that f(i) = t.
  */
-trait Locator[@spec(Boolean, Int, Long, Double) T] {
+trait Locator[@spec(Boolean, Int, Long, Double) T] extends Serializable{
   /**
    * Whether the instance contains the key
    * @param key The key to query

--- a/saddle-core/src/main/scala/org/saddle/mat/MatCols.scala
+++ b/saddle-core/src/main/scala/org/saddle/mat/MatCols.scala
@@ -23,7 +23,7 @@ import org.saddle.scalar._
  * An IndexedSeq of Vecs which must all have the same length; a container for
  * 2D data for a Frame.
  */
-class MatCols[A: ST](cols: IndexedSeq[Vec[A]]) extends IndexedSeq[Vec[A]] {
+class MatCols[A: ST](cols: IndexedSeq[Vec[A]]) extends IndexedSeq[Vec[A]] with Serializable{
   require(cols.length < 2 || cols.forall(_.length == cols(0).length),
           "Vecs must all be the same length")
 

--- a/saddle-core/src/main/scala/org/saddle/scalar/ScalarTag.scala
+++ b/saddle-core/src/main/scala/org/saddle/scalar/ScalarTag.scala
@@ -27,7 +27,7 @@ import org.saddle.array.Sorter
  * as an array. Often implicitly required when dealing with objects in Saddle
  */
 trait ScalarTag[@spec(Boolean, Int, Long, Float, Double) T]
-  extends ClassManifest[T] with SpecializedFactory[T] with CouldBeOrdered[T] with CouldBeNumber[T] with ScalarHelperOps[T] {
+  extends ClassManifest[T] with SpecializedFactory[T] with CouldBeOrdered[T] with CouldBeNumber[T] with ScalarHelperOps[T] with Serializable{
   // representation of missing data
   def missing: T
   def isMissing(t: T): Boolean

--- a/saddle-core/src/main/scala/org/saddle/scalar/ScalarTagTime.scala
+++ b/saddle-core/src/main/scala/org/saddle/scalar/ScalarTagTime.scala
@@ -51,7 +51,7 @@ object ScalarTagTime extends ScalarTagAny[DateTime] {
   override def makeSorter(implicit ord: ORD[DateTime]): Sorter[DateTime] =
     Sorter.timeSorter
 
-  private val fmtZ = DateTimeFormat.forPattern("YYYY-MM-dd HH:mm:ss.SSSZZ")
+  @transient lazy private val fmtZ = DateTimeFormat.forPattern("YYYY-MM-dd HH:mm:ss.SSSZZ")
 
   override def show(v: DateTime) = Option(v) map { fmtZ.print(_) } getOrElse("NA")
 

--- a/saddle-core/src/main/scala/org/saddle/vec/VecTime.scala
+++ b/saddle-core/src/main/scala/org/saddle/vec/VecTime.scala
@@ -35,11 +35,11 @@ import org.saddle.buffer.BufferInt
  */
 class VecTime(val times: Vec[Long], val tzone: DateTimeZone = ISO_CHRONO.getZone) extends Vec[DateTime] {
 
-  val scalarTag = ScalarTagTime
+  @transient lazy val scalarTag = ScalarTagTime
 
-  val chrono = ISO_CHRONO.withZone(tzone)
+  @transient lazy val chrono = ISO_CHRONO.withZone(tzone)
 
-  private val lmf = scalar.ScalarTagLong
+  @transient lazy private val lmf = scalar.ScalarTagLong
 
   private def l2t(l: Long) = if (lmf.isMissing(l)) scalarTag.missing else new DateTime(l, chrono)
   private def t2l(t: DateTime) = if (scalarTag.isMissing(t)) lmf.missing else t.getMillis
@@ -112,8 +112,8 @@ class VecTime(val times: Vec[Long], val tzone: DateTimeZone = ISO_CHRONO.getZone
 }
 
 object VecTime {
-  private val sm = ScalarTagTime
-  private val sl = ScalarTagLong
+  @transient lazy private val sm = ScalarTagTime
+  @transient lazy private val sl = ScalarTagLong
 
   /**
    * Create a new VecTime from an array of times

--- a/saddle-core/src/test/scala/org/saddle/FrameCheck.scala
+++ b/saddle-core/src/test/scala/org/saddle/FrameCheck.scala
@@ -20,6 +20,7 @@ import org.specs2.mutable.Specification
 import org.specs2.ScalaCheck
 import org.scalacheck.{ Gen, Arbitrary }
 import org.scalacheck.Prop._
+import Serde.serializedCopy
 
 class FrameCheck extends Specification with ScalaCheck {
 
@@ -78,6 +79,15 @@ class FrameCheck extends Specification with ScalaCheck {
       val f = Frame(Vec("a", "b", "c"), Vec("d", "e", "f"))
       f.T must_== Frame(Vec("a", "d"), Vec("b", "e"), Vec("c", "f"))
     }
+
+    "serialization works" in  {
+      forAll { f: Frame[Int, Int, Double] =>
+        f must_== serializedCopy(f)
+      }
+    }
+
+
+
   }
 
 }

--- a/saddle-core/src/test/scala/org/saddle/IndexCheck.scala
+++ b/saddle-core/src/test/scala/org/saddle/IndexCheck.scala
@@ -16,6 +16,7 @@
 
 package org.saddle
 
+import org.saddle.Serde._
 import org.specs2.mutable.Specification
 import org.specs2.ScalaCheck
 import org.scalacheck.{Gen, Arbitrary}
@@ -125,6 +126,18 @@ class IndexCheck extends Specification with ScalaCheck {
         ixs1.join(ixs2, how=index.OuterJoin).index.isMonotonic must beTrue
       }
     }
+
+    "serialization works" in  {
+      implicit val arbIndex = Arbitrary(IndexArbitraries.indexIntNoDups)
+
+      forAll { (ix1: Index[Int], ix2: Index[Int]) => {
+        ix1 must_== serializedCopy(ix1)
+        ix2 must_== serializedCopy(ix2)
+      }
+      }
+    }
+
+
   }
 
   "Time Index Tests" in {
@@ -232,5 +245,17 @@ class IndexCheck extends Specification with ScalaCheck {
         ixs1.join(ixs2, how=index.OuterJoin).index.isMonotonic must beTrue
       }
     }
+
+    "serialization works" in  {
+
+      implicit val arbIndex = Arbitrary(IndexArbitraries.indexTimeWithDups)
+
+      forAll { (ix1: Index[DateTime], ix2: Index[DateTime]) => {
+        ix1 must_== serializedCopy(ix1)
+        ix2 must_== serializedCopy(ix2)
+      }
+      }
+    }
+
   }
 }

--- a/saddle-core/src/test/scala/org/saddle/MatCheck.scala
+++ b/saddle-core/src/test/scala/org/saddle/MatCheck.scala
@@ -17,6 +17,7 @@
 package org.saddle
 
 import mat.MatMath
+import org.saddle.Serde._
 import org.specs2.mutable.Specification
 import org.specs2.ScalaCheck
 import org.scalacheck.{Gen, Arbitrary}
@@ -252,4 +253,12 @@ class MatCheck extends Specification with ScalaCheck {
        }
      }
    }
- }
+
+  "serialization works" in  {
+    forAll { ma: Mat[Double] =>
+      ma must_== serializedCopy(ma)
+    }
+  }
+
+
+}

--- a/saddle-core/src/test/scala/org/saddle/Serde.scala
+++ b/saddle-core/src/test/scala/org/saddle/Serde.scala
@@ -1,0 +1,23 @@
+package org.saddle
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
+
+/**
+ * utility methods for tests
+ */
+object Serde {
+
+  /** provides a deep copy of this input object by serializing and deserializing it*/
+  def serializedCopy[T](input: T): T = {
+
+    val baos = new ByteArrayOutputStream()
+    val oos = new ObjectOutputStream(baos)
+
+    oos.writeObject(input)
+    oos.close()
+
+    val bais = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray))
+    bais.readObject().asInstanceOf[T]
+  }
+
+}

--- a/saddle-core/src/test/scala/org/saddle/SeriesCheck.scala
+++ b/saddle-core/src/test/scala/org/saddle/SeriesCheck.scala
@@ -16,6 +16,7 @@
 
 package org.saddle
 
+import org.saddle.Serde._
 import org.specs2.mutable.Specification
 import org.specs2.ScalaCheck
 import org.scalacheck.{Gen, Arbitrary}
@@ -258,6 +259,13 @@ class SeriesCheck extends Specification with ScalaCheck {
         f.melt.pivot must_== f
       }
     }
+
+    "serialization works" in  {
+        forAll { s1: Series[Int, Double] =>
+          s1 must_== serializedCopy(s1)
+      }
+    }
+
   }
 
   "Series[DateTime, Double] Tests" in {
@@ -347,5 +355,15 @@ class SeriesCheck extends Specification with ScalaCheck {
         s1.reindex(s2.index).index must_== s2.index
       }
     }
+
+    "serialization works" in  {
+
+      implicit val ser = Arbitrary(SeriesArbitraries.seriesDateTimeDoubleNoDup)
+
+      forAll { s: Series[DateTime, Double] =>
+        s must_== serializedCopy(s)
+      }
+    }
+
   }
 }

--- a/saddle-core/src/test/scala/org/saddle/VecCheck.scala
+++ b/saddle-core/src/test/scala/org/saddle/VecCheck.scala
@@ -20,8 +20,9 @@ import org.specs2.mutable.Specification
 import org.specs2.ScalaCheck
 import org.scalacheck.{Gen, Arbitrary}
 import org.scalacheck.Prop._
-import org.saddle._
-import scalar.{Scalar, Value}
+import org.saddle.scalar.Value
+import Serde.serializedCopy
+
 
 /**
  * Test on properties of Vec
@@ -365,5 +366,15 @@ class VecCheck extends Specification with ScalaCheck {
         (v.length > 0 && v.at(0).isNA) || (v.pad.hasNA must beFalse)
       }
     }
+
+    "serialization works" in  {
+      forAll { v:Vec[Double] =>
+        v must_== serializedCopy(v)
+      }
+    }
+
   }
+
+
+
 }


### PR DESCRIPTION
In order to use Saddle data types in a context where java serialisation is necessary (e.g. when a data processing framework is "checkpointing" in-progress results during a computation made of many steps), I updated the Vec, Index, Series, Mat and Frame classes/traits so they are now serialisable. Class members have been marked as "transient lazy" whenever re-creating them is possible based on other piece of class state. 

I also added unit tests that make sure no data is lost after a serialisation/deserialisation round trip. 

Build number has been increased to 1.3.4-SNAPSHOT. 
