### PR TITLE
make toArray public on Mat

### DIFF
--- a/saddle-core/src/main/scala/org/saddle/Mat.scala
+++ b/saddle-core/src/main/scala/org/saddle/Mat.scala
@@ -403,8 +403,12 @@ trait Mat[@spec(Boolean, Int, Long, Double) A] extends NumericOps[Mat[A]] with S
   // implement access like matrix(i, j)
   private[saddle] def apply(r: Int, c: Int): A
 
-  // use with caution, may not return copy
-  private[saddle] def toArray: Array[A]
+  /**
+   * Returns the contents of this Mat in an array.
+   * If possible exposes the backing array without copying the elements.
+   * Changes to the returned array may directly modify the contents of the Mat.
+   */
+  def toArray: Array[A]
 
   // use with caution, may not return copy
   private[saddle] def toDoubleArray(implicit ev: NUM[A]): Array[Double]
@@ -543,4 +547,3 @@ object Mat extends BinOpMat {
    */
   def ident(n: Int): Mat[Double] = mat.ident(n)
 }
-

--- a/saddle-core/src/main/scala/org/saddle/mat/MatAny.scala
+++ b/saddle-core/src/main/scala/org/saddle/mat/MatAny.scala
@@ -63,8 +63,7 @@ class MatAny[T: ST](r: Int, c: Int, values: Array[T]) extends Mat[T] {
   // implement access like matrix(i, j)
   private[saddle] def apply(r: Int, c: Int) = apply(r * numCols + c)
 
-  // use with caution, may not return copy
-  private[saddle] def toArray = values
+  def toArray = values
 
   private[saddle] def toDoubleArray(implicit ev: NUM[T]): Array[Double] = arrCopyToDblArr(values)
 
@@ -92,4 +91,3 @@ class MatAny[T: ST](r: Int, c: Int, values: Array[T]) extends Mat[T] {
     case _ => super.equals(o)
   }
 }
-

--- a/saddle-core/src/main/scala/org/saddle/mat/MatBool.scala
+++ b/saddle-core/src/main/scala/org/saddle/mat/MatBool.scala
@@ -66,8 +66,7 @@ class MatBool(r: Int, c: Int, values: Array[Boolean]) extends Mat[Boolean] {
   // implement access like matrix(i, j)
   private[saddle] def apply(r: Int, c: Int) = apply(r * numCols + c)
 
-  // use with caution, may not return copy
-  private[saddle] def toArray = values
+  def toArray = values
 
   private[saddle] def toDoubleArray(implicit ev: NUM[Boolean]): Array[Double] = arrCopyToDblArr(values)
 

--- a/saddle-core/src/main/scala/org/saddle/mat/MatDouble.scala
+++ b/saddle-core/src/main/scala/org/saddle/mat/MatDouble.scala
@@ -65,8 +65,7 @@ class MatDouble(r: Int, c: Int, values: Array[Double]) extends Mat[Double] {
   // implement access like matrix(i, j)
   private[saddle] def apply(r: Int, c: Int) = apply(r * numCols + c)
 
-  // use with caution, may not return copy
-  private[saddle] def toArray: Array[Double] = values
+  def toArray: Array[Double] = values
 
   // use with caution, may not return copy
   private[saddle] def toDoubleArray(implicit ev: NUM[Double]): Array[Double] = values

--- a/saddle-core/src/main/scala/org/saddle/mat/MatInt.scala
+++ b/saddle-core/src/main/scala/org/saddle/mat/MatInt.scala
@@ -64,8 +64,7 @@ class MatInt(r: Int, c: Int, values: Array[Int]) extends Mat[Int] {
   // implement access like matrix(i, j)
   private[saddle] def apply(r: Int, c: Int) = apply(r * numCols + c)
 
-  // use with caution, may not return copy
-  private[saddle] def toArray = values
+  def toArray = values
 
   private[saddle] def toDoubleArray(implicit ev: NUM[Int]): Array[Double] = arrCopyToDblArr(values)
 

--- a/saddle-core/src/main/scala/org/saddle/mat/MatLong.scala
+++ b/saddle-core/src/main/scala/org/saddle/mat/MatLong.scala
@@ -64,8 +64,7 @@ class MatLong(r: Int, c: Int, values: Array[Long]) extends Mat[Long] {
   // implement access like matrix(i, j)
   private[saddle] def apply(r: Int, c: Int) = apply(r * numCols + c)
 
-  // use with caution, may not return copy
-  private[saddle] def toArray = values
+  def toArray = values
 
   private[saddle] def toDoubleArray(implicit ev: NUM[Long]): Array[Double] = arrCopyToDblArr(values)
 


### PR DESCRIPTION
For some applications it is crucial not to hide the backing array. (e.g. https://github.com/pityka/saddle-linalg)